### PR TITLE
Fixed the crash that appears on iOS 12 due to an invalid access to ac…

### DIFF
--- a/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
+++ b/AsyncDisplayKit/Details/_ASDisplayViewAccessiblity.mm
@@ -168,7 +168,9 @@ static void CollectAccessibilityElementsForView(_ASDisplayView *view, NSMutableA
 
 - (id)accessibilityElementAtIndex:(NSInteger)index
 {
-  return self.accessibleElements[index];
+  if (index < [self.accessibilityElements count])
+    return [self.accessibilityElements objectAtIndex:index];
+  return nil;
 }
 
 - (NSInteger)indexOfAccessibilityElement:(id)element


### PR DESCRIPTION
To reproduce the crash:

Launch the app
Go to ios settings and activate speak in Accessiibility
Go back to our app and double tap on some text to show the UIMenuController

So far the only reasons I saw for this is that there aren't any accessibility elements in our view.